### PR TITLE
Syntax error

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -648,7 +648,7 @@ ul .task-list-item ul::before {left: 0.15em !important}
 
  /* Editor CodeBlock TEXT Appearance */
 .cm-s-obsidian pre.HyperMD-codeblock {
-  font-family: var(--font-family-editor); !important;
+  font-family: var(--font-family-editor) !important;
   font-size: var(--font-size-code) !important;
   padding: 1px !important;
   display: block;


### PR DESCRIPTION
Line 651 has extra semicolon

font-family: var(--font-family-editor); !important;

should be (no semicolon before !important

font-family: var(--font-family-editor) !important;