### PR TITLE
Color italic, highlight and strikethrough emphasis.

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -17,6 +17,7 @@
   --background-modifier-error-hover: #EF4D44;
   --background-modifier-cover: rgba(0, 0, 0, 0.6);
   --text-accent: #61D29D;
+  --text-accent-second: #F0D879;
   --text-accent-hover: #C9A9F9;
   --text-normal: #D2D8E1;
   --text-muted: #D2D8E1;
@@ -213,13 +214,20 @@ strong, .cm-strong {
 
 /* emphasis in preview and editor */
 em, .cm-em {
-  color: var(--text-muted);
+  color: var(--text-accent-second);
   font-style: italic;
 }
 
+/* emphasis in preview and editor */
+.highlight, mark, .cm-highlight {
+  background-color: var(--text-title-h3) !important;
+  color: var(--background-primary) !important;
+}
+
 /* strikethrough in preview and editor */
-s, .cm-strikethrough {
-  color: var(--text-muted);
+s, del, .cm-strikethrough {
+  color: var(--text-error);
+  opacity: 70%;
 }
 
 /* list in editor */


### PR DESCRIPTION
Hello!
I've been using this theme for quite some time.

These changes I use locally as css snippets and I consider them an improvement worth being added to the theme.
Because italic and crossed are barely noticeable in large walls of text.
And highlight looks better that way in my humble opinion.

| Before | After |
| --- | --- |
| <img width="196" alt="image" src="https://github.com/Chrismettal/Obsidian-Behave-dark/assets/48155493/7b8c036e-f6e9-4148-98f6-4a428233d47d">| <img width="197" alt="image" src="https://github.com/Chrismettal/Obsidian-Behave-dark/assets/48155493/4dc27dd4-de03-416b-9463-b06ad8ff141a"> |

